### PR TITLE
Make cheatsheet appear properly on side navigation and next page

### DIFF
--- a/content/en/docs/intro/CheatSheet.md
+++ b/content/en/docs/intro/CheatSheet.md
@@ -1,4 +1,8 @@
-# Cheat Sheet - HELM
+---
+title: "Cheat Sheet"
+description: "Helm cheatsheet"
+weight: 4
+---
 
 Helm cheatsheet featuring all the necessary commands required to manage an application through Helm.
 


### PR DESCRIPTION
Currently cheatsheet doesn't show up in the sidebar navigation and "next" page title shows as empty for "Using Helm" page, hopefully this fixes that issue